### PR TITLE
Fixed Object removal in enumeration.

### DIFF
--- a/Assets/lizzard/Scripts/Proxies/LizzardObjectsProxy.cs
+++ b/Assets/lizzard/Scripts/Proxies/LizzardObjectsProxy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using lizzard.Interfaces;
 using lizzard.UnityComponents;
 using UnityEngine;
@@ -104,10 +105,14 @@ namespace lizzard.Proxies
         /// </summary>
         public virtual void DeleteAllNullObjects()
         {
-            foreach (var o in _objects)
+            var dictionary = _objects
+			    .Where(entry => entry.Value?.GameObject?.Equals(null) ?? true)
+			    .ToDictionary(entry => entry.Key,
+		        entry => entry.Value);
+
+            foreach (var entry in dictionary)
             {
-                if (o.Value.GameObject == null)
-                    RemoveObject(o.Key, false);
+			    RemoveObject(entry.Key, false);
             }
         }
 


### PR DESCRIPTION
1) Collection modification while enumerating over it is not allowed.

2) This line is done to confirm that object was destroyed.
`entry => entry.Value?.GameObject?.Equals(null) ?? true`
 Unity has issue with that is doing null check on interfaces.
